### PR TITLE
Safely unwrap original before launching CropperView

### DIFF
--- a/ImageDeskew/ContentView.swift
+++ b/ImageDeskew/ContentView.swift
@@ -294,13 +294,9 @@ struct ContentView: View {
                     _ in loadImage()
                 }
 
-                if original != nil {
-                    NavigationLink("Crop / Deskew")
-                    {
-                        CropperView(input: original!)
-                        {
-                            corrected = $0
-                        }
+                if let orig = original {
+                    NavigationLink("Crop / Deskew") {
+                        CropperView(input: orig) { corrected = $0 }
                     }
                     .buttonStyle(.bordered)
                 }


### PR DESCRIPTION
## Summary
- use optional binding in ContentView before presenting `CropperView`

## Testing
- `swift test` *(fails: no such module `SwiftUI`)*

------
https://chatgpt.com/codex/tasks/task_e_6862b6f78570832d92d70674ec8aa2c4