### PR TITLE
Remove SwiftData framework linkage

### DIFF
--- a/ImageDeskew/ImageDeskewApp.swift
+++ b/ImageDeskew/ImageDeskewApp.swift
@@ -6,7 +6,6 @@
 //
 
 import SwiftUI
-import SwiftData
 
 @main
 struct ImageDeskewApp: App {

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,7 @@ let package = Package(
                 .linkedFramework("SwiftUI"),
                 .linkedFramework("PhotosUI"),
                 .linkedFramework("Vision"),
-                .linkedFramework("CoreImage"),
-                .linkedFramework("SwiftData")
+                .linkedFramework("CoreImage")
             ]
         ),
         .testTarget(


### PR DESCRIPTION
## Summary
- drop the SwiftData import from `ImageDeskewApp.swift`
- remove `SwiftData` from linker settings in `Package.swift`

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6862b6f9b1cc832db0d3f5ea5153d487