### PR TITLE
Update README with macOS requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Image correction app
 
 ## Building with Swift Package Manager
 
+> **Note**: This project relies on SwiftUI, PhotosUI, Vision and other Apple
+> frameworks. Building and running therefore requires **macOS** with Xcode.
+> Attempting a Linux build will fail because these frameworks are unavailable.
+
 1. Clone the repository and open the project directory:
    ```bash
    git clone <repo-url>


### PR DESCRIPTION
## Summary
- document macOS requirement in README

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6862cba57d20832daaf5b54b0e2d7e44