### PR TITLE
Remove unused width/height variables

### DIFF
--- a/ImageDeskew/ContentView.swift
+++ b/ImageDeskew/ContentView.swift
@@ -227,8 +227,6 @@ struct CropEngine {
         try? handler.perform([req])
         let o = (req.results as? [VNRectangleObservation])?.first
             if let o = o {
-                let w = CGFloat(cropped.width)
-                let h = CGFloat(cropped.height)
                 #if DEBUG
                 print("\n Detected Vision corners (in pixels of crop):")
                 print("Top Left:     \(o.topLeft.denormalized(to: cropped))")


### PR DESCRIPTION
## Summary
- clean up CropEngine.process by removing unused local variables

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6862d68ba784832dbeb78b4b38fc0f83