### PR TITLE
Remove redundant rounding in CropEngine.process

### DIFF
--- a/ImageDeskew/ContentView.swift
+++ b/ImageDeskew/ContentView.swift
@@ -179,11 +179,6 @@ struct CropEngine {
             height: nhClamped * CGFloat(cg.height)
         ).integral
 
-        // Sanity check - ensure rounding produced valid values
-        pix.origin.x = round(pix.origin.x)
-        pix.origin.y = round(pix.origin.y)
-        pix.size.width = round(pix.size.width)
-        pix.size.height = round(pix.size.height)
 
         #if DEBUG
         print("Cropping CGImage to rect: \(pix)")


### PR DESCRIPTION
## Summary
- remove manual rounding of the crop rectangle in `CropEngine.process`

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6862dfe2fa34832d83084a2dbf670e86