### PR TITLE
Share CIContext in CropEngine

### DIFF
--- a/ImageDeskew/ContentView.swift
+++ b/ImageDeskew/ContentView.swift
@@ -78,6 +78,9 @@ struct CropSnapshot: Equatable {
 
 // MARK: - Processing engine
 struct CropEngine {
+    /// Shared CIContext reused across calls. Thread‑safe for read‑only operations
+    static let ciContext = CIContext()
+
     static func resize(rect r0: CGRect,
                        handleIndex idx: Int,
                        translation t: CGSize,
@@ -248,7 +251,7 @@ struct CropEngine {
             
             // 4. Perspective correction
         let ci = CIImage(cgImage: cropped)
-        let ctx = CIContext()
+        let ctx = ciContext
         let outCG: CGImage
         if let o = o {
             let filt = CIFilter.perspectiveCorrection()

--- a/ImageDeskewTests/ImageDeskewTests.swift
+++ b/ImageDeskewTests/ImageDeskewTests.swift
@@ -92,4 +92,22 @@ final class ImageDeskewTests: XCTestCase {
         XCTAssertEqual(out?.size.width, rect.width, accuracy: 1)
         XCTAssertEqual(out?.size.height, rect.height, accuracy: 1)
     }
+    func testProcessPerformance() {
+        let size = CGSize(width: 200, height: 200)
+        let renderer = UIGraphicsImageRenderer(size: size)
+        let base = renderer.image { ctx in
+            UIColor.gray.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
+        let oriented = UIImage(cgImage: base.cgImage!, scale: base.scale, orientation: .right)
+        let crop = CGRect(origin: .zero, size: size)
+        measure {
+            _ = CropEngine.process(image: oriented,
+                                   displaySize: size,
+                                   scale: 1,
+                                   offset: .zero,
+                                   cropRect: crop)
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- reuse a shared `CIContext` in `CropEngine` for repeated operations
- update usage inside `process` to rely on the shared context
- add a performance test exercising `CropEngine.process`

## Testing
- `swift test --enable-test-discovery` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6862e9ec18a4832d809b8b175a50f607